### PR TITLE
[Feat] 대댓글 기능 구현

### DIFF
--- a/backend/src/main/java/com/back/fairytale/domain/comments/controller/CommentsController.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/controller/CommentsController.kt
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/backend/src/main/java/com/back/fairytale/domain/comments/controller/CommentsController.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/controller/CommentsController.kt
@@ -17,20 +17,25 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
-@Tag(name = "댓글 API", description = "동화에 대한 댓글을 작성, 조회, 수정, 삭제하는 API입니다.")
+@Tag(name = "댓글 API", description = "동화에 대한 댓글 및 대댓글을 작성, 조회, 수정, 삭제하는 API입니다.")
 @RestController
 @RequestMapping("/api")
 class CommentsController (
     private val commentsService: CommentsService
 ) {
     // 댓글 작성
-    @Operation(summary = "댓글 작성", description = "동화에 대한 댓글을 작성합니다.")
+    @Operation(summary = "댓글 및 대댓글 작성", description = "동화에 대한 댓글을 작성합니다. parentId를 포함하면 대댓글이 작성됩니다.")
     @PostMapping("/fairytales/{fairytaleId}/comments")
     fun createComments(
         @PathVariable fairytaleId: Long,
         @RequestBody request: @Valid CommentsRequest,
         @AuthenticationPrincipal customOAuth2User: CustomOAuth2User
     ): ResponseEntity<CommentsResponse> {
+        // URL과 요청 본문의 fairytaleId가 일치하는지 검증
+        if (fairytaleId != request.fairytaleId) {
+            throw IllegalArgumentException("URL과 요청 본문의 동화 Id가 일치하지 않습니다.")
+        }
+
         val response = commentsService.createComments(request, customOAuth2User.id)
 
         // 새로 생성된 리소스의 URI를 생성
@@ -41,11 +46,11 @@ class CommentsController (
     }
 
     // 댓글 조회
-    @Operation(summary = "댓글 조회", description = "동화에 대한 댓글을 조회합니다.")
+    @Operation(summary = "댓글 조회", description = "동화의 댓글을 계층 구조로 조회합니다. 부모-자식 관계가 유지된 상태로 반환됩니다.")
     @GetMapping("/fairytales/{fairytaleId}/comments")
     fun getComments(
         @PathVariable fairytaleId: Long,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
+        @PageableDefault(size = 10) pageable: Pageable
     ): ResponseEntity<Page<CommentsResponse>> =
         ResponseEntity.ok(commentsService.getCommentsByFairytale(fairytaleId, pageable))
 

--- a/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsRequest.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsRequest.kt
@@ -13,5 +13,7 @@ data class CommentsRequest(
         max = 500,
         message = "댓글은 최대 500자까지 입력할 수 있습니다."
     )
-    val content: String
+    val content: String,
+
+    val parentId: Long? = null // 부모 댓글 ID
 )

--- a/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsResponse.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsResponse.kt
@@ -10,6 +10,10 @@ data class CommentsResponse(
     val content: String,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
+    val parentId: Long? = null, // 부모 댓글 ID
+    val depth: Int, // 댓글 깊이 (0: 부모 댓글, 1: 대댓글)
+    val hasChildren: Boolean, // 자식 댓글 존재 여부
+    val childrenCount: Int, // 자식 댓글 수
 ) {
     companion object {
         @JvmStatic
@@ -20,7 +24,11 @@ data class CommentsResponse(
                 nickname = comments.user.nickname,
                 content = comments.content,
                 createdAt = comments.createdAt,
-                updatedAt = comments.updatedAt
+                updatedAt = comments.updatedAt,
+                parentId = comments.parent?.id,
+                depth = comments.getDepth(),
+                hasChildren = comments.hasChildren(),
+                childrenCount = comments.children.size,
             )
         }
     }

--- a/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsResponse.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/dto/CommentsResponse.kt
@@ -31,5 +31,21 @@ data class CommentsResponse(
                 childrenCount = comments.children.size,
             )
         }
+
+        @JvmStatic
+        fun from(comments: Comments, childrenCount: Long): CommentsResponse { // childrenCount를 외부에서 주입위한 오버로딩
+            return CommentsResponse(
+                id = comments.id ?: throw IllegalArgumentException("댓글 ID는 필수입니다."),
+                fairytaleId = comments.fairytale.id ?: throw IllegalArgumentException("동화 ID는 필수입니다."),
+                nickname = comments.user.nickname,
+                content = comments.content,
+                createdAt = comments.createdAt,
+                updatedAt = comments.updatedAt,
+                parentId = comments.parent?.id,
+                depth = comments.getDepth(),
+                hasChildren = comments.hasChildren(),
+                childrenCount = childrenCount.toInt() // 외부에서 계산된 값 사용
+            )
+        }
     }
 }

--- a/backend/src/main/java/com/back/fairytale/domain/comments/entity/Comments.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/entity/Comments.kt
@@ -24,7 +24,7 @@ class Comments (
     @Column(length = 500, nullable = false)
     var content: String,
 
-    // 대댓글 기능용 부모 댓글
+    // 부모 댓글
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", nullable = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -53,12 +53,12 @@ class Comments (
     }
 
     // 편의 메서드들
-    fun isReply(): Boolean = parent != null
-    fun isParentComment(): Boolean = parent == null
-    fun hasChildren(): Boolean = children.isNotEmpty()
-    fun getDepth(): Int = if (parent == null) 0 else 1
+    fun isReply(): Boolean = parent != null // 대댓글 여부
+    fun isParentComment(): Boolean = parent == null // 부모 댓글 여부
+    fun hasChildren(): Boolean = children.isNotEmpty() // 자식 댓글 존재 여부
+    fun getDepth(): Int = if (parent == null) 0 else 1 // 0: 부모 댓글, 1: 대댓글
 
-        // Comments 수정
+    // Comments 수정
     fun updateContent(content: String) {
         this.content = content
     }

--- a/backend/src/main/java/com/back/fairytale/domain/comments/entity/Comments.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/entity/Comments.kt
@@ -43,7 +43,7 @@ class Comments (
         validateHierarchy()
     }
 
-    // 계층 구조 유효성 검사
+    // 계층 구조 유효성 검사 (자식댓글은 자식댓글을 가질 수 없음)
     private fun validateHierarchy() {
         val parentComment = parent ?: return
 

--- a/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
@@ -1,7 +1,6 @@
 package com.back.fairytale.domain.comments.repository
 
 import com.back.fairytale.domain.comments.entity.Comments
-import com.back.fairytale.domain.fairytale.entity.Fairytale
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph

--- a/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
@@ -5,9 +5,27 @@ import com.back.fairytale.domain.fairytale.entity.Fairytale
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 
 interface CommentsRepository : JpaRepository<Comments, Long> {
-    // 특정 fairytale에 대한 comments를 조회하는 method
+    // 특정 동화(fairytale)에 대한 comments를 조회하는 method
     fun findByFairytale(fairytale: Fairytale, pageable: Pageable): Page<Comments>
+
+    // 특정 동화(fairytale)에 대한 댓글을 계층 구조로 페이징하여 조회
+    @Query ("""
+        SELECT c FROM Comments c
+        WHERE c.fairytale.id = :fairytaleId
+        ORDER BY 
+            COALESCE(c.parent.id, c.id) ASC, /* 부모 댓글 기준 정렬 */
+            c.parent.id ASC NULLS FIRST, /* 부모 댓글 우선 정렬 */
+            c.createdAt ASC /* 같은 부모 내에서는 생성일 기준 정렬 */
+    """)
+    fun findByFairytaleIdOrderByHierarchy(
+        @Param("fairytaleId") fairytaleId: Long,
+        pageable: Pageable
+    ): Page<Comments>
+
+
 }

--- a/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
@@ -16,10 +16,10 @@ interface CommentsRepository : JpaRepository<Comments, Long> {
         SELECT c FROM Comments c
         WHERE c.fairytale.id = :fairytaleId
         ORDER BY 
-            COALESCE(c.parent.id, c.id) ASC, /* 부모 댓글 기준 정렬 */
-            c.parent.id ASC NULLS FIRST, /* 부모 댓글 우선 정렬 */
-            c.createdAt ASC /* 같은 부모 내에서는 생성일 기준 정렬 */
-    """)
+            COALESCE(c.parent.id, c.id) ASC,
+            c.parent.id ASC NULLS FIRST,
+            c.createdAt ASC
+    """) // Order by는 순서대로 부모 댓글 기준 정렬, 부모 댓글 우선 정렬, 같은 부모 내에서는 생성일 기준 정렬
     fun findByFairytaleIdOrderByHierarchy(
         @Param("fairytaleId") fairytaleId: Long,
         pageable: Pageable

--- a/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
+++ b/backend/src/main/java/com/back/fairytale/domain/comments/repository/CommentsRepository.kt
@@ -11,9 +11,6 @@ import org.springframework.data.repository.query.Param
 
 
 interface CommentsRepository : JpaRepository<Comments, Long> {
-    // 특정 동화(fairytale)에 대한 comments를 조회하는 method
-    fun findByFairytale(fairytale: Fairytale, pageable: Pageable): Page<Comments>
-
     // 특정 동화(fairytale)에 대한 댓글을 계층 구조로 페이징하여 조회
     @EntityGraph(attributePaths = ["user", "fairytale"]) // N+1 문제 해결을 위한 EntityGraph 사용
     @Query ("""

--- a/backend/src/main/resources/db/migration/V999__create_comments_performance_indexes.sql
+++ b/backend/src/main/resources/db/migration/V999__create_comments_performance_indexes.sql
@@ -1,0 +1,55 @@
+-- 댓글 성능 최적화를 위한 인덱스 생성 (H2 Database)
+-- 대댓글 기능 및 계층 구조 조회 최적화
+--
+-- !! 개발환경(H2) 수동 실행 방법 !!
+-- 1. Spring Boot 애플리케이션 실행 (IDE에서 메인 클래스 실행 또는 ./gradlew bootRun)
+-- 2. 브라우저에서 H2 Console 접속: http://localhost:8080/h2-console
+-- 3. 로그인 화면에서 설정 입력:
+--    - JDBC URL: jdbc:h2:./db_dev
+--    - User Name: sa
+--    - Password: (비워두기)
+--    - Connect 버튼 클릭
+-- 4. 아래 SQL문들을 복사해서 H2 Console에 붙여넣고 Run 버튼 클릭
+-- 5. 인덱스 생성 확인: SHOW INDEXES FROM comments;
+--
+-- !! 운영환경(PostgreSQL) 실행 방법 !!
+-- 
+-- [방법 1: 수동 실행 (권장)]
+-- 1. PostgreSQL 클라이언트 접속 (pgAdmin, DBeaver, psql 등)
+-- 2. 아래 PostgreSQL용 SQL 실행:
+--    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comments_hierarchy_query ON comments(fairytale_id, parent_id, created_at);
+--    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comments_parent_count ON comments(parent_id) WHERE parent_id IS NOT NULL;
+--    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comments_fairytale_parent ON comments(fairytale_id, parent_id);
+--    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comments_user_created ON comments(user_id, created_at);
+-- 3. 인덱스 생성 확인: \d comments (psql) 또는 SELECT * FROM pg_indexes WHERE tablename = 'comments';
+--
+-- [방법 2: Flyway 자동 실행]
+-- 1. application-prod.yml에 Flyway 설정 추가:
+--    spring:
+--      flyway:
+--        enabled: true
+--        locations: classpath:db/migration
+--        baseline-on-migrate: true
+-- 2. 이 파일명을 V1__create_comments_performance_indexes.sql로 변경 (기존 마이그레이션 번호에 맞게)
+-- 3. 현재 파일의 SQL을 CONCURRENTLY 키워드 추가한 PostgreSQL 버전으로 수정 (현재 파일의 SQL은 H2용이므로 PostgreSQL에 맞게 변경 필요)
+-- 4. 애플리케이션 배포 시 자동 실행됨
+
+-- 1. 계층 구조 조회 최적화 인덱스
+-- findByFairytaleIdOrderByHierarchy 쿼리 최적화
+CREATE INDEX IF NOT EXISTS idx_comments_hierarchy_query 
+ON comments(fairytale_id, parent_id, created_at);
+
+-- 2. 부모 댓글별 자식 수 조회 최적화 인덱스  
+-- countChildrenByParentId 쿼리 최적화
+CREATE INDEX IF NOT EXISTS idx_comments_parent_count 
+ON comments(parent_id);
+
+-- 3. 복합 인덱스 (선택적 최적화)
+-- fairytale_id + parent_id 조합으로 특정 동화의 부모/자식 댓글 빠른 조회
+CREATE INDEX IF NOT EXISTS idx_comments_fairytale_parent 
+ON comments(fairytale_id, parent_id);
+
+-- 4. 사용자별 댓글 조회 최적화 (기존 기능 지원)
+-- 사용자가 작성한 댓글 조회 시 성능 향상
+CREATE INDEX IF NOT EXISTS idx_comments_user_created 
+ON comments(user_id, created_at);

--- a/backend/src/test/java/com/back/fairytale/domain/comments/service/CommentsServiceTest.kt
+++ b/backend/src/test/java/com/back/fairytale/domain/comments/service/CommentsServiceTest.kt
@@ -52,12 +52,16 @@ class CommentsServiceTest {
         return mock { on { this.id } doReturn id }
     }
 
-    private fun createMockComment(id: Long, user: User, fairytale: Fairytale, content: String): Comments {
+    private fun createMockComment(id: Long, user: User, fairytale: Fairytale, content: String, parent: Comments? = null): Comments {
         return mock {
             on { this.id } doReturn id
             on { this.user } doReturn user
             on { this.fairytale } doReturn fairytale
             on { this.content } doReturn content
+            on { this.parent } doReturn parent
+            on { this.getDepth() } doReturn (if (parent == null) 0 else 1)
+            on { this.hasChildren() } doReturn false
+            on { this.children } doReturn mutableListOf()
         }
     }
 
@@ -97,29 +101,6 @@ class CommentsServiceTest {
         }
     }
 
-    @Test
-    @DisplayName("[성공] 동화별 댓글 목록 조회")
-    fun getCommentsByFairytale_Success() {
-        // Given
-        val mockUser = createMockUser(1L, "테스트유저")
-        val mockFairytale = createMockFairytale(10L)
-        val pageable = PageRequest.of(0, 10)
-        val commentsList = listOf(
-            createMockComment(1L, mockUser, mockFairytale, "댓글 1"),
-            createMockComment(2L, mockUser, mockFairytale, "댓글 2")
-        )
-        val commentsPage = PageImpl(commentsList, pageable, commentsList.size.toLong())
-
-        given(fairytaleRepository.findById(mockFairytale.id!!)).willReturn(Optional.of(mockFairytale))
-        given(commentsRepository.findByFairytale(mockFairytale, pageable)).willReturn(commentsPage)
-
-        // When
-        val response = commentsService.getCommentsByFairytale(mockFairytale.id!!, pageable)
-
-        // Then
-        assertThat(response.content.size).isEqualTo(2)
-        assertThat(response.content[0].content).isEqualTo("댓글 1")
-    }
 
     @Test
     @DisplayName("[성공] 댓글 수정")
@@ -193,5 +174,109 @@ class CommentsServiceTest {
         assertThrows<IllegalStateException> {
             commentsService.deleteComments(commentId, mockOtherUser.id!!)
         }
+    }
+
+    // 대댓글 관련 테스트 케이스
+    @Test
+    @DisplayName("[성공] 대댓글 작성")
+    fun createReply_Success() {
+        // Given
+        val mockUser = createMockUser(1L, "대댓글작성자")
+        val mockFairytale = createMockFairytale(10L)
+        val parentComment = createMockComment(1L, mockUser, mockFairytale, "부모 댓글")
+        val replyRequest = CommentsRequest(mockFairytale.id!!, "대댓글 내용", parentComment.id)
+        val savedReply = createMockComment(2L, mockUser, mockFairytale, "대댓글 내용", parentComment)
+
+        given(userRepository.findById(mockUser.id!!)).willReturn(Optional.of(mockUser))
+        given(fairytaleRepository.findById(mockFairytale.id!!)).willReturn(Optional.of(mockFairytale))
+        given(commentsRepository.findById(parentComment.id!!)).willReturn(Optional.of(parentComment))
+        given(commentsRepository.save(any<Comments>())).willReturn(savedReply)
+
+        // When
+        val response = commentsService.createComments(replyRequest, mockUser.id!!)
+
+        // Then
+        assertThat(response.content).isEqualTo("대댓글 내용")
+        assertThat(response.parentId).isEqualTo(parentComment.id)
+        assertThat(response.depth).isEqualTo(1)
+        verify(commentsRepository, times(1)).save(any<Comments>())
+    }
+
+    @Test
+    @DisplayName("[실패] 대댓글 작성 - 부모 댓글을 찾을 수 없음")
+    fun createReply_Fail_ParentNotFound() {
+        // Given
+        val mockUser = createMockUser(1L, "대댓글작성자")
+        val mockFairytale = createMockFairytale(10L)
+        val replyRequest = CommentsRequest(mockFairytale.id!!, "대댓글 내용", 999L)
+
+        given(userRepository.findById(mockUser.id!!)).willReturn(Optional.of(mockUser))
+        given(fairytaleRepository.findById(mockFairytale.id!!)).willReturn(Optional.of(mockFairytale))
+        given(commentsRepository.findById(999L)).willReturn(Optional.empty())
+
+        // When & Then
+        assertThrows<EntityNotFoundException> {
+            commentsService.createComments(replyRequest, mockUser.id!!)
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] 대댓글 작성 - 다른 동화의 댓글에 대댓글 시도")
+    fun createReply_Fail_DifferentFairytale() {
+        // Given
+        val mockUser = createMockUser(1L, "대댓글작성자")
+        val mockFairytale1 = createMockFairytale(10L)
+        val mockFairytale2 = createMockFairytale(20L)
+        val parentComment = createMockComment(1L, mockUser, mockFairytale2, "다른 동화의 댓글")
+        val replyRequest = CommentsRequest(mockFairytale1.id!!, "대댓글 내용", parentComment.id)
+
+        given(userRepository.findById(mockUser.id!!)).willReturn(Optional.of(mockUser))
+        given(fairytaleRepository.findById(mockFairytale1.id!!)).willReturn(Optional.of(mockFairytale1))
+        given(commentsRepository.findById(parentComment.id!!)).willReturn(Optional.of(parentComment))
+
+        // When & Then
+        assertThrows<IllegalArgumentException> {
+            commentsService.createComments(replyRequest, mockUser.id!!)
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] 계층구조 댓글 조회 (N+1 최적화)")
+    fun getCommentsByFairytale_WithHierarchy_Success() {
+        // Given
+        val mockUser = createMockUser(1L, "테스트유저")
+        val mockFairytale = createMockFairytale(10L)
+        val pageable = PageRequest.of(0, 10)
+        
+        val parentComment = createMockComment(1L, mockUser, mockFairytale, "부모 댓글")
+        val replyComment1 = createMockComment(2L, mockUser, mockFairytale, "대댓글1", parentComment)
+        val replyComment2 = createMockComment(3L, mockUser, mockFairytale, "대댓글2", parentComment)
+        
+        val commentsList = listOf(parentComment, replyComment1, replyComment2)
+        val commentsPage = PageImpl(commentsList, pageable, commentsList.size.toLong())
+        
+        // N+1 방지를 위한 childrenCount Map 시뮬레이션
+        val childrenCountResults = listOf(arrayOf<Any>(1L, 2L)) // parentId=1, count=2
+        
+        given(commentsRepository.findByFairytaleIdOrderByHierarchy(mockFairytale.id!!, pageable))
+            .willReturn(commentsPage)
+        given(commentsRepository.countChildrenByParentId(listOf(1L)))
+            .willReturn(childrenCountResults)
+
+        // When
+        val response = commentsService.getCommentsByFairytale(mockFairytale.id!!, pageable)
+
+        // Then
+        assertThat(response.content.size).isEqualTo(3)
+        assertThat(response.content[0].parentId).isNull()
+        assertThat(response.content[0].depth).isEqualTo(0)
+        assertThat(response.content[1].parentId).isEqualTo(1L)
+        assertThat(response.content[1].depth).isEqualTo(1)
+        assertThat(response.content[2].parentId).isEqualTo(1L)
+        assertThat(response.content[2].depth).isEqualTo(1)
+        
+        // Repository 메서드 호출 검증
+        verify(commentsRepository, times(1)).findByFairytaleIdOrderByHierarchy(mockFairytale.id!!, pageable)
+        verify(commentsRepository, times(1)).countChildrenByParentId(listOf(1L))
     }
 }


### PR DESCRIPTION
Close #47 

## 📌 과제 설명
Comments 도메인에 대댓글 기능을 추가하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. Entity에 parent_id를 추가하여 부모댓글이 자식댓글을 가질 수 있도록 구현하였습니다.
2. 성능 유지를 위해 자식댓글이 자식댓글을 가질 수 없도록 하였습니다.
3. Entity수정에 따라 dto에 필드를 추가하였습니다.
4. Repository에서 계층별로 조회한 후 페이징 처리하도록 변경하였습니다.
5. Repository에 N+1문제 방지 로직을 추가하였습니다.
6. Service에 관련 로직을 추가하였습니다.
7. Controller에 관련 로직을 추가하였습니다.
8. 기능 추가에 따른 테스트케이스를 추가하였습니다.
9. 성능 향상을 위해 인덱스 생성 기능을 추가하였습니다. 다만 배포에 바로 적용되지는 않고 수동으로 추가할 수 있도록 설정해놓았습니다. resource/db에 설정방법을 주석으로 달아놓았습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
