### PR TITLE
[Fix] 댓글 도메인 테스트 버그 픽스

### DIFF
--- a/backend/src/test/java/com/back/fairytale/domain/comments/controller/CommentsControllerUnitTest.kt
+++ b/backend/src/test/java/com/back/fairytale/domain/comments/controller/CommentsControllerUnitTest.kt
@@ -44,7 +44,7 @@ import java.time.LocalDateTime
     ]
 )
 @AutoConfigureMockMvc(addFilters = false)
-class CommentsControllerTest {
+class CommentsControllerUnitTest {
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -241,7 +241,7 @@ class CommentsControllerTest {
         }
 
         @Test
-        @DisplayName("POST /api/fairytales/{fairytaleId}/comments - fairytaleId 불일치 실패")
+        @DisplayName("POST /api/fairytales/{fairytaleId}/comments - URL과 요청 본문의 동화Id 일치확인 실패")
         fun createCommentsFailureFairytaleIdMismatch() {
             // URL의 fairytaleId와 요청 body의 fairytaleId가 다른 경우
             val mismatchRequest = commentsRequest.copy(fairytaleId = 999L)
@@ -262,7 +262,7 @@ class CommentsControllerTest {
                     }
                     .with(csrf())
             )
-                .andExpect(status().isInternalServerError) // IllegalArgumentException → 500
+                .andExpect(status().isBadRequest)
 
             // Service 메서드는 호출되지 않아야 함 (Controller에서 검증 실패)
             verify(exactly = 0) { commentsService.createComments(any(), any()) }

--- a/backend/src/test/java/com/back/fairytale/domain/comments/service/CommentsServiceUnitTest.kt
+++ b/backend/src/test/java/com/back/fairytale/domain/comments/service/CommentsServiceUnitTest.kt
@@ -26,7 +26,7 @@ import java.util.*
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension::class)
-class CommentsServiceTest {
+class CommentsServiceUnitTest {
 
     @Mock
     private lateinit var commentsRepository: CommentsRepository

--- a/backend/src/test/java/com/back/fairytale/domain/thoughts/controller/ThoughtsControllerUnitTest.kt
+++ b/backend/src/test/java/com/back/fairytale/domain/thoughts/controller/ThoughtsControllerUnitTest.kt
@@ -41,7 +41,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
         )
     ]
 )
-class ThoughtsControllerTest {
+class ThoughtsControllerUnitTest {
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/backend/src/test/java/com/back/fairytale/domain/thoughts/service/ThoughtsServiceUnitTest.kt
+++ b/backend/src/test/java/com/back/fairytale/domain/thoughts/service/ThoughtsServiceUnitTest.kt
@@ -25,7 +25,7 @@ import org.mockito.quality.Strictness
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension::class)
-class ThoughtsServiceTest {
+class ThoughtsServiceUnitTest {
 
     @Mock
     private lateinit var thoughtsRepository: ThoughtsRepository


### PR DESCRIPTION
Close #57 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
통합테스트 추가 후 놓치고 있던 댓글 도메인 테스트코드의 마이너한 버그를 고쳤습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 통합테스트 당시 GlobalExceptionHandler에 추가한 변수로 인해 발생한 버그를 고쳤습니다.
2. 가독성을 위해 단위테스트 파일이름에 Unit을 추가했습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
